### PR TITLE
Update bootstrap nodes

### DIFF
--- a/network_bridge.py
+++ b/network_bridge.py
@@ -106,9 +106,6 @@ class NetworkBridge:
             # Connect to existing network
             config.p2p.bootstrap_nodes = [
                 "/ip4/genesis.peoplesainetwork.com/tcp/30300",
-                "/ip4/127.0.0.1/tcp/30301",  # Local CSP network node
-                "/ip4/127.0.0.1/tcp/30302",
-                "/ip4/127.0.0.1/tcp/30303",
             ]
             config.p2p.dns_seed_domain = "peoplesainetwork.com"
             

--- a/personal_ai_router.py
+++ b/personal_ai_router.py
@@ -688,11 +688,9 @@ class PersonalAIRouter:
             # Start P2P network
             self.p2p_network.start_network()
             
-            # Try to join web4ai network with default bootstrap nodes
+            # Try to join the Peoples AI network using the public bootstrap node
             bootstrap_nodes = [
-                ("127.0.0.1", 9001),
-                ("127.0.0.1", 9002),
-                ("127.0.0.1", 9003)
+                ("genesis.peoplesainetwork.com", 30300)
             ]
             
             # Join the network


### PR DESCRIPTION
## Summary
- configure CSP network bridge to use genesis.peoplesainetwork.com:30300
- update PersonalAI router bootstrap node to genesis.peoplesainetwork.com

## Testing
- `pytest -q` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_687842da56488328be7b2f7b0be61620