### PR TITLE
Add persistence for user settings and API keys

### DIFF
--- a/api_keys_storage.py
+++ b/api_keys_storage.py
@@ -1,0 +1,20 @@
+import os
+from typing import Dict
+from persistent_storage import load_json, save_json
+
+FILE_PATH = "instance/api_keys.json"
+
+def load_api_keys() -> Dict[str, str]:
+    """Load API keys from disk and populate environment variables."""
+    data = load_json(FILE_PATH)
+    for env_key, value in data.items():
+        if value:
+            os.environ[env_key] = value
+    return data
+
+
+def save_api_keys(keys: Dict[str, str]) -> None:
+    """Persist API keys to disk."""
+    existing = load_json(FILE_PATH)
+    existing.update(keys)
+    save_json(FILE_PATH, existing)

--- a/persistent_storage.py
+++ b/persistent_storage.py
@@ -1,0 +1,19 @@
+import json
+import os
+from typing import Any, Dict
+
+def load_json(file_path: str) -> Dict[str, Any]:
+    """Load JSON data from a file."""
+    if os.path.exists(file_path):
+        try:
+            with open(file_path, 'r') as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+def save_json(file_path: str, data: Dict[str, Any]) -> None:
+    """Save JSON data to a file, creating directories if needed."""
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    with open(file_path, 'w') as f:
+        json.dump(data, f, indent=2)

--- a/settings_storage.py
+++ b/settings_storage.py
@@ -1,0 +1,11 @@
+from typing import Dict, Any
+from persistent_storage import load_json, save_json
+
+FILE_PATH = "instance/user_settings.json"
+
+def load_settings() -> Dict[str, Any]:
+    return load_json(FILE_PATH)
+
+
+def save_settings(settings: Dict[str, Any]) -> None:
+    save_json(FILE_PATH, settings)


### PR DESCRIPTION
## Summary
- add minimal JSON persistence helpers
- persist AuthManager user data to disk
- load/save API keys
- load/save UI settings

## Testing
- `python -m py_compile auth_system.py app.py persistent_storage.py api_keys_storage.py settings_storage.py`
- `pytest -q` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_68785884673c8328928567b142e967ca