### PR TITLE
Fix capability list in model details API

### DIFF
--- a/ai_models.py
+++ b/ai_models.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional, Any, Union
 import aiohttp
@@ -74,15 +74,15 @@ class AIModel:
     cost_per_1k_tokens: float = 0.0
     context_window: int = 4096
     is_active: bool = True
-    custom_headers: Dict[str, str] = None
-    capabilities: List[ModelCapability] = None
+    custom_headers: Dict[str, str] = field(default_factory=dict)
+    capabilities: List[ModelCapability] = field(default_factory=list)
     supports_vision: bool = False
     supports_audio: bool = False
     supports_video: bool = False
     supports_functions: bool = False
     model_type: str = "llm"  # llm, embedding, image, audio, video, multimodal
-    input_modalities: List[str] = None
-    output_modalities: List[str] = None
+    input_modalities: List[str] = field(default_factory=list)
+    output_modalities: List[str] = field(default_factory=list)
     deployment_type: str = "cloud"  # cloud, local, hybrid
 
 class AIModelManager:

--- a/app.py
+++ b/app.py
@@ -2208,7 +2208,7 @@ def get_models_detailed():
                 'model_type': getattr(model, 'model_type', 'text'),
                 'input_modalities': getattr(model, 'input_modalities', ['text']),
                 'output_modalities': getattr(model, 'output_modalities', ['text']),
-                'capabilities': [cap.value for cap in getattr(model, 'capabilities', [])]
+                'capabilities': [cap.value for cap in (getattr(model, 'capabilities', []) or [])]
             }
             
             model_list.append(model_dict)


### PR DESCRIPTION
## Summary
- handle missing capabilities in `get_models_detailed`
- ensure `AIModel` dataclass uses list/dict default factories

## Testing
- `pytest -q` *(fails: Connection refused for RAG test)*

------
https://chatgpt.com/codex/tasks/task_e_687a0366de948328a72d9beedc90ed3b