### PR TITLE
Fix async initialization hang

### DIFF
--- a/app.py
+++ b/app.py
@@ -384,33 +384,6 @@ def initialize_router():
                 logger.error(f"Email intelligence system initialization failed: {e}")
                 email_intelligence = None
             
-            # FIXED: Initialize ML models asynchronously with error handling (NON-BLOCKING)
-            def init_async_components():
-                try:
-                    loop = asyncio.new_event_loop()
-                    asyncio.set_event_loop(loop)
-
-                    if router:
-                        loop.run_until_complete(router.initialize())
-                    if advanced_ml_classifier:
-                        loop.run_until_complete(advanced_ml_classifier.initialize())
-                    if intelligent_routing_engine:
-                        loop.run_until_complete(intelligent_routing_engine.initialize())
-                    if real_time_analytics:
-                        loop.run_until_complete(real_time_analytics.start())
-
-                    logger.info("Async ML models initialized")
-                    loop.close()
-                except Exception as e:
-                    logger.error(f"Async ML models initialization failed: {e}")
-                    if 'loop' in locals():
-                        try:
-                            loop.close()
-                        except:
-                            pass
-
-            # FIXED: Run async initialization in background thread (NON-BLOCKING)
-            threading.Thread(target=init_async_components, daemon=True).start()
             
             logger.info("ML Router and Advanced Features initialized successfully")
             
@@ -5220,15 +5193,54 @@ with app.app_context():
     # db.create_all()
     
     
-    # FIXED: Initialize router after models are imported (NON-BLOCKING)
-    def start_initialization():
+    # FIXED: Initialize ML models asynchronously with error handling (NON-BLOCKING)
+    def init_async_components():
+        """Initialize async components in background thread to prevent blocking"""
+        try:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+            if router:
+                loop.run_until_complete(router.initialize())
+            if advanced_ml_classifier:
+                loop.run_until_complete(advanced_ml_classifier.initialize())
+            if intelligent_routing_engine:
+                loop.run_until_complete(intelligent_routing_engine.initialize())
+            if real_time_analytics:
+                loop.run_until_complete(real_time_analytics.start())
+
+            logger.info("\u2705 Async ML models initialized successfully")
+
+        except Exception as e:
+            logger.error(f"\u274C Async ML models initialization failed: {e}")
+            import traceback
+            traceback.print_exc()
+        finally:
+            if 'loop' in locals():
+                try:
+                    loop.close()
+                except:
+                    pass
+
+    # FIXED: Initialize router in background thread (NON-BLOCKING)
+    def start_router_initialization():
+        """Start router initialization in background to prevent blocking Flask"""
         try:
             initialize_router()
-            logger.info("Router initialization completed")
-        except Exception as e:
-            logger.error(f"Router initialization failed: {e}")
+            logger.info("\u2705 Router initialization completed")
 
-    threading.Thread(target=start_initialization, daemon=True).start()
+            # Then start async components
+            init_async_components()
+
+        except Exception as e:
+            logger.error(f"\u274C Router initialization failed: {e}")
+            import traceback
+            traceback.print_exc()
+
+    initialization_thread = threading.Thread(target=start_router_initialization, daemon=True)
+    initialization_thread.start()
+
+    logger.info("\ud83d\ude80 ML Router startup initiated - Flask server starting...")
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000, debug=True)


### PR DESCRIPTION
## Summary
- run ML router async components in background thread
- initialize router in its own thread then start async components

## Testing
- `pip install requests`
- `pip install aiohttp`
- `pytest -q` *(fails: ConnectionRefusedError: localhost:5000)*

------
https://chatgpt.com/codex/tasks/task_e_687b4fd731208328bf3a970ded764b4f