### PR TITLE
Fix agent DB operations and context

### DIFF
--- a/app.py
+++ b/app.py
@@ -5224,17 +5224,18 @@ with app.app_context():
     def init_async_components():
         """Initialize async components in background thread to prevent blocking"""
         try:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
+            with app.app_context():
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
 
-            if router:
-                loop.run_until_complete(router.initialize())
-            if advanced_ml_classifier:
-                loop.run_until_complete(advanced_ml_classifier.initialize())
-            if intelligent_routing_engine:
-                loop.run_until_complete(intelligent_routing_engine.initialize())
-            if real_time_analytics:
-                loop.run_until_complete(real_time_analytics.start())
+                if router:
+                    loop.run_until_complete(router.initialize())
+                if advanced_ml_classifier:
+                    loop.run_until_complete(advanced_ml_classifier.initialize())
+                if intelligent_routing_engine:
+                    loop.run_until_complete(intelligent_routing_engine.initialize())
+                if real_time_analytics:
+                    loop.run_until_complete(real_time_analytics.start())
 
             logger.info("\u2705 Async ML models initialized successfully")
 

--- a/ml_router.py
+++ b/ml_router.py
@@ -190,7 +190,7 @@ class MLEnhancedQueryRouter:
         try:
             from models import AgentRegistration
             
-            db_agents = AgentRegistration.query.filter_by(is_active=True).all()
+            db_agents = self.db.session.query(AgentRegistration).filter_by(is_active=True).all()
             
             for db_agent in db_agents:
                 # Convert string categories to QueryCategory enum
@@ -227,7 +227,7 @@ class MLEnhancedQueryRouter:
         try:
             from models import AgentRegistration
             
-            db_agent = AgentRegistration.query.get(agent.id)
+            db_agent = self.db.session.get(AgentRegistration, agent.id)
             
             if db_agent:
                 # Update existing agent
@@ -266,7 +266,7 @@ class MLEnhancedQueryRouter:
         try:
             from models import AgentRegistration
             
-            db_agent = AgentRegistration.query.get(agent_id)
+            db_agent = self.db.session.get(AgentRegistration, agent_id)
             if db_agent:
                 db_agent.is_active = False
                 self.db.session.commit()


### PR DESCRIPTION
## Summary
- connect async init to Flask app context
- use `db.session` for AgentRegistration queries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp', ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_687d868b6bd883289c4f176d01fdacc4